### PR TITLE
Reproduction case of exception thrown when disabling check thats also in `XepPatchChecks`

### DIFF
--- a/src/main/java/com/example/HelloWorld.java
+++ b/src/main/java/com/example/HelloWorld.java
@@ -1,5 +1,6 @@
 package com.example;
 
+import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSet;
 
 public final class HelloWorld {
@@ -15,6 +16,10 @@ public final class HelloWorld {
   public static ImmutableSet<String> helloWorld() {
     ImmutableSet<String> set = ImmutableSet.of("Hello world!");
     return ImmutableSet.copyOf(set);
+  }
+
+  public static ImmutableList<Integer> helloWorldCharacters() {
+    return "Hello World!".chars().boxed().collect(ImmutableList.toImmutableList());
   }
 
   public static boolean isEmpty(String str) {


### PR DESCRIPTION
When disabling a check using `-Xep:XXX:OFF` while the check is listed in `-XepPatchChecks` results in a `NoSuchElementException` being thrown when EP tries to get the severity level of the check.

This PR introduces code that triggers the `StaticImport` check to get a reproducible case.

The issue can be reproduced using the following `mvn` invocation:
```sh
mvn clean install \
-Perror-prone \
-Derror-prone.patch-args="-XepPatchLocation:IN_PLACE -XepPatchChecks:StaticImport -Xep:StaticImport:OFF"
```

And results in the following exception:
```sh
[ERROR] Failed to execute goal org.apache.maven.plugins:maven-compiler-plugin:3.10.1:compile (default-compile) on project error-prone-demo: Compilation failure
[ERROR] ~/error-prone-demo/src/main/java/com/example/HelloWorld.java:[22,64] An unhandled exception was thrown by the Error Prone static analysis plugin.
[ERROR]      Please report this at https://github.com/google/error-prone/issues/new and include the following:
[ERROR]
[ERROR]      error-prone version: 2.19.1
[ERROR]      BugPattern: StaticImport
[ERROR]      Stack Trace:
[ERROR]      java.util.NoSuchElementException: No value present
[ERROR]   	at java.base/java.util.Optional.get(Optional.java:143)
[ERROR]   	at com.google.errorprone.matchers.Description.severity(Description.java:78)
[ERROR]   	at com.google.errorprone.ErrorProneAnalyzer.lambda$finished$1(ErrorProneAnalyzer.java:138)
[ERROR]   	at com.google.errorprone.VisitorState.reportMatch(VisitorState.java:301)
[ERROR]   	at com.google.errorprone.scanner.Scanner.reportMatch(Scanner.java:127)
[ERROR]   	at com.google.errorprone.scanner.ErrorProneScanner.processMatchers(ErrorProneScanner.java:448)
[ERROR]   	at com.google.errorprone.scanner.ErrorProneScanner.visitMemberSelect(ErrorProneScanner.java:726)
[ERROR]   	at com.google.errorprone.scanner.ErrorProneScanner.visitMemberSelect(ErrorProneScanner.java:150)
```